### PR TITLE
6 cleanup

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -29,10 +29,6 @@ class EventsController < ApplicationController
     }
   end
 
-  def new_event_params
-    params.permit(:friend_id, :friend_name, :gym_membership_id, :gym_name)
-  end
-
   def create_event_params
     params[:date_time] = DateTime.civil(
       params[:date]['when(1i)'].to_i,

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,21 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-
-  def self.user_stub
-    User.new(
-      id: 1,
-      attributes: {
-        email: '123@test.com',
-        full_name: 'Joe Shmoe',
-        google_id: 789,
-        google_image_url: 'pretty face',
-        zip_code: '80227',
-        summary: 'Muy guesta gimnasios',
-        goal: 'Gain Muscle',
-        availability_morning: true,
-        availability_afternoon: true,
-        availability_evening: false
-      }
-    )
-  end
 end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -8,7 +8,7 @@
         <h5 class="card-title">
           Mission</h5>
         <h6 class="card-subtitle mb-2">
-          Find your 'swole mate' and fitness besties by adding your gyms to your profile, adding friends and creating events to go work out.</h6>
+          Find your future 'swolemate' and fitness bestie at your gym and schedule a workout together!</h6>
       </div>
     </div>
   </div>

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,14 +1,16 @@
-- Changes Implemented:
-  - ...
-  - ...
+### Changes Implemented:
+  -
 
-- Quality Control Checklist:
+### Quality Control Checklist:
 
-  - [ ] Code adheres to Rubocop styling (if unavoidable infractions, please clarify below)
-  - [ ] 100% SimpleCov test coverage (if below, please clarify below)
+  - [ ] Code adheres to Rubocop styling.  If not, please clarify below:
+    -
+  - [ ] 100% SimpleCov test coverage.  If not, please clarify below:
+    -
   - [ ] Last commit has passing Travis build
 
+### Blockers (if applicable):
+  -
 
-- Blockers (if applicable):
-
-- Next Steps & Additional Notes:
+### Next Steps & Additional Notes:
+  -

--- a/spec/facades/back_end_facade_spec.rb
+++ b/spec/facades/back_end_facade_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BackEndFacade do
+describe BackEndFacade, type: :facade do
   describe '.get_user_friends' do
     context 'when the user has friends' do
       it "can return an array of the user's friends", :vcr do

--- a/spec/features/events/new_spec.rb
+++ b/spec/features/events/new_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe 'new event page', type: :feature do
   end
 
   context 'when I log in as an authenticated user' do
+    include_context 'logged in as authenticated user'
+
     context 'when I visit the new event page' do
       let(:create_params) do
         {
@@ -116,9 +118,9 @@ RSpec.describe 'new event page', type: :feature do
 
         before do
           allow(BackEndFacade).to receive(:create_event).with(create_event_params).and_return(new_event)
-          allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([friend])
-          allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([current_user_gym_membership])
-          allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([new_event])
+          allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([friend])
+          allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([current_user_gym_membership])
+          allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([new_event])
 
           fill_in 'activity', with: activity
           select year, from: 'date[when(1i)]'
@@ -131,7 +133,7 @@ RSpec.describe 'new event page', type: :feature do
         end
 
         it 'redirects me to the User Dashboard page' do
-          expect(page).to have_current_path(dashboard_path(@user.id), ignore_query: true)
+          expect(page).to have_current_path(dashboard_path(user.id), ignore_query: true)
         end
 
         it 'displays a success flash message' do

--- a/spec/features/events/new_spec.rb
+++ b/spec/features/events/new_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'new event page', type: :feature do
   end
 
   context 'when I log in as an authenticated user' do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     context 'when I visit the new event page' do

--- a/spec/features/gym_search/index_spec.rb
+++ b/spec/features/gym_search/index_spec.rb
@@ -1,17 +1,19 @@
 require 'rails_helper'
 
-describe 'gyms near me page', type: :feature, :vcr do
-  before do
-    allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
-    allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
-    allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([])
+describe 'gyms near me page', :vcr, type: :feature do
+  include_context 'logged in as authenticated user'
 
-    visit dashboard_path(@user.id)
+  before do
+    allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([])
+
+    visit dashboard_path(user.id)
     within('#gyms') { click_on 'Find Gyms Near Me' }
   end
 
   it 'can find gyms near me', :vcr do
-    expect(page).to have_content("Gyms Near #{@user.zip_code}")
+    expect(page).to have_content("Gyms Near #{user.zip_code}")
 
     within '#gyms' do
       within '#BJBXzKYxQAXZKb5W6HrRnA' do
@@ -27,6 +29,7 @@ describe 'gyms near me page', type: :feature, :vcr do
       expect(page).to have_link("Rishi's Community Yoga")
       click_on "Rishi's Community Yoga"
     end
+
     expect(page).to have_current_path(gym_path('BJBXzKYxQAXZKb5W6HrRnA'), ignore_query: true)
   end
 end

--- a/spec/features/gym_search/index_spec.rb
+++ b/spec/features/gym_search/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'gyms near me page', :vcr do
+describe 'gyms near me page', type: :feature, :vcr do
   before do
     allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
     allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])

--- a/spec/features/gym_search/index_spec.rb
+++ b/spec/features/gym_search/index_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'gyms near me page', :vcr, type: :feature do
+  # See spec/shared_contexts/features/current_user_shared_context.rb for context
   include_context 'logged in as authenticated user'
 
   before do

--- a/spec/features/gym_search/show/show_member_spec.rb
+++ b/spec/features/gym_search/show/show_member_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'gyms show page: as a gym member', type: :feature do
   describe 'as an authenticated user' do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     let(:current_user_id) { user.id }

--- a/spec/features/gym_search/show/show_member_spec.rb
+++ b/spec/features/gym_search/show/show_member_spec.rb
@@ -1,74 +1,76 @@
 require 'rails_helper'
 
 describe 'gyms show page: as a gym member', type: :feature do
-  let(:current_user_id) { @user.id }
-  let(:yelp_gym_id) { 'BJBXzKYxQAXZKb5W6HrRnA' }
-  let(:name) { 'Planet Fitness' }
-  let(:address) { '123 Main St' }
-  let(:phone) { '123-123-1234' }
-
-  let(:gym) do
-    Gym.new(
-      id: yelp_gym_id,
-      type: 'gym',
-      attributes: {
-        name: name,
-        address: address,
-        phone: phone
-      }
-    )
-  end
-
-  let(:gym_membership) do
-    GymMembership.new(
-      id: 1,
-      type: 'gym',
-      attributes: {
-        gym_name: name,
-        yelp_gym_id: yelp_gym_id
-      }
-    )
-  end
-
-  let(:friend) do
-    User.new(
-      id: 10,
-      attributes: {
-        email: '123@test.com',
-        full_name: 'Joe Shmoe',
-        google_id: 123,
-        google_image_url: 'pretty face',
-        zip_code: '80227',
-        summary: 'Muy guesta gimnasios',
-        goal: 'Gain Weight',
-        availability_morning: true,
-        availability_afternoon: true,
-        availability_evening: false
-      }
-    )
-  end
-
-  let(:non_friend) do
-    User.new(
-      id: 20,
-      attributes: {
-        email: '234@test.com',
-        full_name: 'John Doe',
-        google_id: 234,
-        google_image_url: 'pretty face',
-        zip_code: '80227',
-        summary: 'Muy guesta gimnasios',
-        goal: 'Gain Weight',
-        availability_morning: true,
-        availability_afternoon: false,
-        availability_evening: true
-      }
-    )
-  end
-
-  let(:gym_user_count) { GymUserCount.new(gym_member_count: 2) }
-
   describe 'as an authenticated user' do
+    include_context 'logged in as authenticated user'
+
+    let(:current_user_id) { user.id }
+    let(:yelp_gym_id) { 'BJBXzKYxQAXZKb5W6HrRnA' }
+    let(:name) { 'Planet Fitness' }
+    let(:address) { '123 Main St' }
+    let(:phone) { '123-123-1234' }
+
+    let(:gym) do
+      Gym.new(
+        id: yelp_gym_id,
+        type: 'gym',
+        attributes: {
+          name: name,
+          address: address,
+          phone: phone
+        }
+      )
+    end
+
+    let(:gym_membership) do
+      GymMembership.new(
+        id: 1,
+        type: 'gym',
+        attributes: {
+          gym_name: name,
+          yelp_gym_id: yelp_gym_id
+        }
+      )
+    end
+
+    let(:friend) do
+      User.new(
+        id: 10,
+        attributes: {
+          email: '123@test.com',
+          full_name: 'Joe Shmoe',
+          google_id: 123,
+          google_image_url: 'pretty face',
+          zip_code: '80227',
+          summary: 'Muy guesta gimnasios',
+          goal: 'Gain Weight',
+          availability_morning: true,
+          availability_afternoon: true,
+          availability_evening: false
+        }
+      )
+    end
+
+    let(:non_friend) do
+      User.new(
+        id: 20,
+        attributes: {
+          email: '234@test.com',
+          full_name: 'John Doe',
+          google_id: 234,
+          google_image_url: 'pretty face',
+          zip_code: '80227',
+          summary: 'Muy guesta gimnasios',
+          goal: 'Gain Weight',
+          availability_morning: true,
+          availability_afternoon: false,
+          availability_evening: true
+        }
+      )
+    end
+
+    let(:gym_user_count) { GymUserCount.new(gym_member_count: 2) }
+
     context 'when I visit the gym show page as a gym member' do
       before do
         allow(BackEndFacade).to receive(:get_selected_gym).with(yelp_gym_id).and_return(gym)

--- a/spec/features/gym_search/show/show_non_member_spec.rb
+++ b/spec/features/gym_search/show/show_non_member_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'gyms show page: as a non-gym member', type: :feature do
   describe 'as an authenticated user' do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     let(:current_user_id) { user.id }

--- a/spec/features/gym_search/show/show_non_member_spec.rb
+++ b/spec/features/gym_search/show/show_non_member_spec.rb
@@ -1,38 +1,40 @@
 require 'rails_helper'
 
 describe 'gyms show page: as a non-gym member', type: :feature do
-  let(:current_user_id) { @user.id }
-  let(:yelp_gym_id) { 'BJBXzKYxQAXZKb5W6HrRnA' }
-  let(:name) { 'Planet Fitness' }
-  let(:address) { '123 Main St' }
-  let(:phone) { '123-123-1234' }
-
-  let(:gym) do
-    Gym.new(
-      id: yelp_gym_id,
-      type: 'gym',
-      attributes: {
-        name: name,
-        address: address,
-        phone: phone
-      }
-    )
-  end
-
-  let(:gym_membership) do
-    GymMembership.new(
-      id: 1,
-      type: 'gym',
-      attributes: {
-        gym_name: name,
-        yelp_gym_id: yelp_gym_id
-      }
-    )
-  end
-
-  let(:gym_user_count) { GymUserCount.new(gym_member_count: 2) }
-
   describe 'as an authenticated user' do
+    include_context 'logged in as authenticated user'
+
+    let(:current_user_id) { user.id }
+    let(:yelp_gym_id) { 'BJBXzKYxQAXZKb5W6HrRnA' }
+    let(:name) { 'Planet Fitness' }
+    let(:address) { '123 Main St' }
+    let(:phone) { '123-123-1234' }
+
+    let(:gym) do
+      Gym.new(
+        id: yelp_gym_id,
+        type: 'gym',
+        attributes: {
+          name: name,
+          address: address,
+          phone: phone
+        }
+      )
+    end
+
+    let(:gym_membership) do
+      GymMembership.new(
+        id: 1,
+        type: 'gym',
+        attributes: {
+          gym_name: name,
+          yelp_gym_id: yelp_gym_id
+        }
+      )
+    end
+
+    let(:gym_user_count) { GymUserCount.new(gym_member_count: 2) }
+
     context 'when I visit the gym show page that I am not a member of' do
       before do
         allow(BackEndFacade).to receive(:get_selected_gym).with(yelp_gym_id).and_return(gym)

--- a/spec/features/users/dashboard/experienced_user_spec.rb
+++ b/spec/features/users/dashboard/experienced_user_spec.rb
@@ -1,190 +1,192 @@
 require 'rails_helper'
 
 describe 'experienced user dashboard', type: :feature do
-  let(:user1_params) do
-    {
-      id: 10,
-      attributes: {
-        email: '123@test.com',
-        full_name: 'Joe Shmoe',
-        google_id: 123,
-        google_image_url: 'pretty face',
-        zip_code: '80227',
-        summary: 'Muy guesta gimnasios',
-        goal: 'Gain Weight',
-        availability_morning: true,
-        availability_afternoon: true,
-        availability_evening: false
-      }
-    }
-  end
-
-  let(:user2_params) do
-    {
-      id: 20,
-      attributes: {
-        email: '234@test.com',
-        full_name: 'John Doe',
-        google_id: 234,
-        google_image_url: 'pretty face',
-        zip_code: '80227',
-        summary: 'Muy guesta gimnasios',
-        goal: 'Gain Weight',
-        availability_morning: true,
-        availability_afternoon: false,
-        availability_evening: true
-      }
-    }
-  end
-
-  let(:user3_params) do
-    {
-      id: 30,
-      attributes: {
-        email: '345@test.com',
-        full_name: 'Jane Doe',
-        google_id: 345,
-        google_image_url: 'pretty face',
-        zip_code: '80227',
-        summary: 'Muy guesta gimnasios',
-        goal: 'Gain Weight',
-        availability_morning: false,
-        availability_afternoon: false,
-        availability_evening: true
-      }
-    }
-  end
-
-  let(:gym_membership1_params) do
-    {
-      id: '1',
-      type: 'gym_membership',
-      attributes: {
-        user_id: 1,
-        yelp_gym_id: 'lex65fkcol5gfq89rymmd2',
-        gym_name: 'Kling-Wilkinson'
-      }
-    }
-  end
-
-  let(:gym_membership2_params) do
-    {
-      id: '7',
-      type: 'gym_membership',
-      attributes: {
-        user_id: 1,
-        yelp_gym_id: '6x10s0lbnry4ivkzcjpilk',
-        gym_name: 'Konopelski, Lowe and Haley'
-      }
-    }
-  end
-
-  let(:gym_membership3_params) do
-    {
-      id: '17',
-      type: 'gym_membership',
-      attributes: {
-        user_id: 1,
-        yelp_gym_id: 'wxaw9m796t6wdnsk53uieh',
-        gym_name: 'Funk LLC'
-      }
-    }
-  end
-
-  let(:yelp_gym1_params) do
-    {
-      id: '1',
-      type: 'gym',
-      attributes: {
-        name: 'Planet Fitness',
-        address: 'address1',
-        phone: '123-123-1234'
-      }
-    }
-  end
-
-  let(:yelp_gym2_params) do
-    {
-      id: '2',
-      type: 'gym',
-      attributes: {
-        name: 'Golds Gym',
-        address: 'address2',
-        phone: '234-234-2345'
-      }
-    }
-  end
-
-  let(:yelp_gym3_params) do
-    {
-      id: '3',
-      type: 'gym',
-      attributes: {
-        name: '24Hour Fitness',
-        address: 'address3',
-        phone: '345-345-3456'
-      }
-    }
-  end
-
-  let(:event1_params) do
-    {
-      id: '1',
-      attributes: {
-        user_id: 20,
-        gym_membership_id: 1,
-        activity: 'Bodybuilding',
-        date_time: '2022-07-22T21:41:28.289Z'
-      }
-    }
-  end
-
-  let(:event2_params) do
-    {
-      id: '2',
-      attributes: {
-        user_id: 30,
-        gym_membership_id: 2,
-        date_time: '2022-08-22T21:41:28.289Z',
-        activity: 'Running'
-      }
-    }
-  end
-
-  let(:event3_params) do
-    {
-      id: '3',
-      attributes: {
-        user_id: 20,
-        gym_membership_id: 3,
-        date_time: '2022-09-22T21:41:28.289Z',
-        activity: 'Stretching'
-      }
-    }
-  end
-
-  let(:user_friends) { [User.new(user1_params), User.new(user2_params), User.new(user3_params)] }
-  let(:user_gyms) { [GymMembership.new(gym_membership1_params), GymMembership.new(gym_membership2_params), GymMembership.new(gym_membership3_params)] }
-  let(:searched_gyms) { [Gym.new(yelp_gym1_params), Gym.new(yelp_gym2_params), Gym.new(yelp_gym3_params)] }
-  let(:user_events) { [Event.new(event1_params), Event.new(event2_params), Event.new(event3_params)] }
-
-  before do
-    allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return(user_friends)
-    allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return(user_gyms)
-    allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return(user_events)
-    allow(BackEndFacade).to receive(:get_gyms_near_user).with(@user.zip_code).and_return(searched_gyms)
-  end
-
   context 'when I log in as an authenticated user' do
+    include_context 'logged in as authenticated user'
+
+    let(:user1_params) do
+      {
+        id: 10,
+        attributes: {
+          email: '123@test.com',
+          full_name: 'Joe Shmoe',
+          google_id: 123,
+          google_image_url: 'pretty face',
+          zip_code: '80227',
+          summary: 'Muy guesta gimnasios',
+          goal: 'Gain Weight',
+          availability_morning: true,
+          availability_afternoon: true,
+          availability_evening: false
+        }
+      }
+    end
+
+    let(:user2_params) do
+      {
+        id: 20,
+        attributes: {
+          email: '234@test.com',
+          full_name: 'John Doe',
+          google_id: 234,
+          google_image_url: 'pretty face',
+          zip_code: '80227',
+          summary: 'Muy guesta gimnasios',
+          goal: 'Gain Weight',
+          availability_morning: true,
+          availability_afternoon: false,
+          availability_evening: true
+        }
+      }
+    end
+
+    let(:user3_params) do
+      {
+        id: 30,
+        attributes: {
+          email: '345@test.com',
+          full_name: 'Jane Doe',
+          google_id: 345,
+          google_image_url: 'pretty face',
+          zip_code: '80227',
+          summary: 'Muy guesta gimnasios',
+          goal: 'Gain Weight',
+          availability_morning: false,
+          availability_afternoon: false,
+          availability_evening: true
+        }
+      }
+    end
+
+    let(:gym_membership1_params) do
+      {
+        id: '1',
+        type: 'gym_membership',
+        attributes: {
+          user_id: 1,
+          yelp_gym_id: 'lex65fkcol5gfq89rymmd2',
+          gym_name: 'Kling-Wilkinson'
+        }
+      }
+    end
+
+    let(:gym_membership2_params) do
+      {
+        id: '7',
+        type: 'gym_membership',
+        attributes: {
+          user_id: 1,
+          yelp_gym_id: '6x10s0lbnry4ivkzcjpilk',
+          gym_name: 'Konopelski, Lowe and Haley'
+        }
+      }
+    end
+
+    let(:gym_membership3_params) do
+      {
+        id: '17',
+        type: 'gym_membership',
+        attributes: {
+          user_id: 1,
+          yelp_gym_id: 'wxaw9m796t6wdnsk53uieh',
+          gym_name: 'Funk LLC'
+        }
+      }
+    end
+
+    let(:yelp_gym1_params) do
+      {
+        id: '1',
+        type: 'gym',
+        attributes: {
+          name: 'Planet Fitness',
+          address: 'address1',
+          phone: '123-123-1234'
+        }
+      }
+    end
+
+    let(:yelp_gym2_params) do
+      {
+        id: '2',
+        type: 'gym',
+        attributes: {
+          name: 'Golds Gym',
+          address: 'address2',
+          phone: '234-234-2345'
+        }
+      }
+    end
+
+    let(:yelp_gym3_params) do
+      {
+        id: '3',
+        type: 'gym',
+        attributes: {
+          name: '24Hour Fitness',
+          address: 'address3',
+          phone: '345-345-3456'
+        }
+      }
+    end
+
+    let(:event1_params) do
+      {
+        id: '1',
+        attributes: {
+          user_id: 20,
+          gym_membership_id: 1,
+          activity: 'Bodybuilding',
+          date_time: '2022-07-22T21:41:28.289Z'
+        }
+      }
+    end
+
+    let(:event2_params) do
+      {
+        id: '2',
+        attributes: {
+          user_id: 30,
+          gym_membership_id: 2,
+          date_time: '2022-08-22T21:41:28.289Z',
+          activity: 'Running'
+        }
+      }
+    end
+
+    let(:event3_params) do
+      {
+        id: '3',
+        attributes: {
+          user_id: 20,
+          gym_membership_id: 3,
+          date_time: '2022-09-22T21:41:28.289Z',
+          activity: 'Stretching'
+        }
+      }
+    end
+
+    let(:user_friends) { [User.new(user1_params), User.new(user2_params), User.new(user3_params)] }
+    let(:user_gyms) { [GymMembership.new(gym_membership1_params), GymMembership.new(gym_membership2_params), GymMembership.new(gym_membership3_params)] }
+    let(:searched_gyms) { [Gym.new(yelp_gym1_params), Gym.new(yelp_gym2_params), Gym.new(yelp_gym3_params)] }
+    let(:user_events) { [Event.new(event1_params), Event.new(event2_params), Event.new(event3_params)] }
+
+    before do
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return(user_friends)
+      allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return(user_gyms)
+      allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return(user_events)
+      allow(BackEndFacade).to receive(:get_gyms_near_user).with(user.zip_code).and_return(searched_gyms)
+    end
+
     context 'when I visit my user dashboard' do
-      before { visit dashboard_path(@user.id) }
+      before { visit dashboard_path(user.id) }
 
       it 'displays my name and zip code', :vcr do
         expect(page).to have_css('#profile-header')
 
         within '#profile-header' do
-          expect(page).to have_content(@user.full_name)
-          expect(page).to have_content(@user.zip_code)
+          expect(page).to have_content(user.full_name)
+          expect(page).to have_content(user.zip_code)
         end
       end
 
@@ -247,7 +249,7 @@ describe 'experienced user dashboard', type: :feature do
           click_on 'Find Gyms Near Me'
         end
 
-        expect(page).to have_current_path("/gyms?zip_code=#{@user.zip_code}")
+        expect(page).to have_current_path("/gyms?zip_code=#{user.zip_code}")
       end
 
       it 'displays the gyms I am a member at', :vcr do
@@ -276,7 +278,7 @@ describe 'experienced user dashboard', type: :feature do
           click_on 'Remove'
         end
 
-        expect(page).to have_current_path(dashboard_path(@user.id))
+        expect(page).to have_current_path(dashboard_path(user.id))
         expect(page).to have_content('Gym removed')
       end
 
@@ -305,7 +307,7 @@ describe 'experienced user dashboard', type: :feature do
           click_on 'Delete'
         end
 
-        expect(page).to have_current_path(dashboard_path(@user.id))
+        expect(page).to have_current_path(dashboard_path(user.id))
         expect(page).to have_content('Workout deleted')
       end
     end

--- a/spec/features/users/dashboard/experienced_user_spec.rb
+++ b/spec/features/users/dashboard/experienced_user_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
-RSpec.describe 'experienced user dashboard' do
+
+describe 'experienced user dashboard', type: :feature do
   let(:user1_params) do
     {
       id: 10,

--- a/spec/features/users/dashboard/experienced_user_spec.rb
+++ b/spec/features/users/dashboard/experienced_user_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'experienced user dashboard', type: :feature do
   context 'when I log in as an authenticated user' do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     let(:user1_params) do

--- a/spec/features/users/dashboard/new_user_spec.rb
+++ b/spec/features/users/dashboard/new_user_spec.rb
@@ -1,18 +1,20 @@
 require 'rails_helper'
 
 describe 'new user dashboard', type: :feature do
-  let(:empty_arr) { [] }
-
-  before do
-    allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return(empty_arr)
-    allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return(empty_arr)
-    allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return(empty_arr)
-    allow(BackEndFacade).to receive(:get_gyms_near_user).with(@user.zip_code).and_return(empty_arr)
-  end
-
   context 'when I log in as an authenticated user' do
+    include_context 'logged in as authenticated user'
+
+    let(:empty_arr) { [] }
+
+    before do
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return(empty_arr)
+      allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return(empty_arr)
+      allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return(empty_arr)
+      allow(BackEndFacade).to receive(:get_gyms_near_user).with(user.zip_code).and_return(empty_arr)
+    end
+
     context 'when I visit my user dashboard' do
-      before { visit dashboard_path(@user.id) }
+      before { visit dashboard_path(user.id) }
 
       context "when I don't have any friends" do
         it 'displays "You currently have no friends."', :vcr do

--- a/spec/features/users/dashboard/new_user_spec.rb
+++ b/spec/features/users/dashboard/new_user_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
-RSpec.describe 'new user dashboard' do
+
+describe 'new user dashboard', type: :feature do
   let(:empty_arr) { [] }
 
   before do

--- a/spec/features/users/dashboard/new_user_spec.rb
+++ b/spec/features/users/dashboard/new_user_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'new user dashboard', type: :feature do
   context 'when I log in as an authenticated user' do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     let(:empty_arr) { [] }

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'edit user profile' do
+describe 'edit user profile', type: :feature do
   let(:user1_params) do
     {
       id: 10,

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'edit user profile', type: :feature do
+  # See spec/shared_contexts/features/current_user_shared_context.rb for context
   include_context 'logged in as authenticated user'
 
   let(:user1_params) do

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'edit user profile', type: :feature do
+  include_context 'logged in as authenticated user'
+
   let(:user1_params) do
     {
       id: 10,
@@ -97,43 +99,43 @@ describe 'edit user profile', type: :feature do
       'availability_evening' => '0'
     }
   end
-  let(:user) { ApplicationRecord.user_stub }
+
   let(:user_friends) { [User.new(user1_params), User.new(user2_params)] }
   let(:user_gyms) { [GymMembership.new(gym_membership1_params), GymMembership.new(gym_membership2_params)] }
   let(:user_events) { [Event.new(event1_params), Event.new(event2_params)] }
 
   before do
-    allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return(user_friends)
-    allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return(user_gyms)
-    allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return(user_events)
+    allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return(user_friends)
+    allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return(user_gyms)
+    allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return(user_events)
   end
 
   it "can click on the link from the current user's profile page and be taken to the edit form", :vcr do
     allow(BackEndFacade).to receive(:get_user_friends).with(user.id.to_s).and_return(user_friends)
 
-    visit profile_path(@user.id)
+    visit profile_path(user.id)
     click_on 'Edit Profile'
 
-    expect(page).to have_current_path(profile_edit_path(@user.id))
+    expect(page).to have_current_path(profile_edit_path(user.id))
   end
 
   it 'can fill out a form to update a user and gives a flash message when you successfully update a user', :vcr do
     allow(BackEndFacade).to receive(:get_user_friends).with(user.id.to_s).and_return(user_friends)
-    allow(BackEndService).to receive(:update_user).with(user_blob, @user.id).and_return(user)
+    allow(BackEndService).to receive(:update_user).with(user_blob, user.id).and_return(user)
 
-    visit profile_edit_path(@user.id)
+    visit profile_edit_path(user.id)
 
-    expect(page).to have_field(:full_name, with: @user.full_name.to_s)
-    expect(page).to have_field(:email, with: @user.email.to_s)
-    expect(page).to have_field(:zip_code, with: @user.zip_code.to_s)
-    expect(page).to have_field(:summary, with: @user.summary.to_s)
-    expect(page).to have_field(:goal, with: @user.goal.to_s)
+    expect(page).to have_field(:full_name, with: user.full_name.to_s)
+    expect(page).to have_field(:email, with: user.email.to_s)
+    expect(page).to have_field(:zip_code, with: user.zip_code.to_s)
+    expect(page).to have_field(:summary, with: user.summary.to_s)
+    expect(page).to have_field(:goal, with: user.goal.to_s)
 
     fill_in :summary, with: 'Joe Mama'
 
     click_on 'Update Profile'
 
-    expect(page).to have_current_path("/profile/#{@user.id}", ignore_query: true)
+    expect(page).to have_current_path("/profile/#{user.id}", ignore_query: true)
     expect(page).to have_content('Your profile has been updated!')
   end
 end

--- a/spec/features/users/profile/profile_current_user_spec.rb
+++ b/spec/features/users/profile/profile_current_user_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'user profile page: current user', type: :feature do
   context 'when I log in as an authenticated user', :vcr do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     before do

--- a/spec/features/users/profile/profile_current_user_spec.rb
+++ b/spec/features/users/profile/profile_current_user_spec.rb
@@ -2,33 +2,35 @@ require 'rails_helper'
 
 describe 'user profile page: current user', type: :feature do
   context 'when I log in as an authenticated user', :vcr do
+    include_context 'logged in as authenticated user'
+
     before do
-      allow(BackEndFacade).to receive(:get_user).with(@user.id).and_return(@user)
-      allow(BackEndFacade).to receive(:get_profile_user).with(@user.id.to_s).and_return(@user)
-      allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
-      allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
-      allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user).with(user.id).and_return(user)
+      allow(BackEndFacade).to receive(:get_profile_user).with(user.id.to_s).and_return(user)
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([])
     end
 
     context 'when I visit my user profile' do
-      before { visit profile_path(@user.id) }
+      before { visit profile_path(user.id) }
 
       it 'displays my name and zip code' do
         within '#profile-header' do
-          expect(page).to have_content(@user.full_name)
-          expect(page).to have_content(@user.zip_code)
+          expect(page).to have_content(user.full_name)
+          expect(page).to have_content(user.zip_code)
         end
       end
 
       it 'displays my summary' do
         within '#user-summary' do
-          expect(page).to have_content(@user.summary)
+          expect(page).to have_content(user.summary)
         end
       end
 
       it 'displays my goal' do
         within '#goal' do
-          expect(page).to have_content(@user.goal)
+          expect(page).to have_content(user.goal)
         end
       end
 

--- a/spec/features/users/profile/profile_friend_spec.rb
+++ b/spec/features/users/profile/profile_friend_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'user profile page: friend', type: :feature do
-  let(:user1_params) do
+  let(:user10_params) do
     {
       id: 10,
       attributes: {
@@ -19,13 +19,15 @@ describe 'user profile page: friend', type: :feature do
     }
   end
 
-  let(:user10) { User.new(user1_params) }
+  let(:user10) { User.new(user10_params) }
 
   context 'when I log in as an authenticated user', :vcr do
+    include_context 'logged in as authenticated user'
+
     before do
-      allow(BackEndFacade).to receive(:get_user).with(@user.id).and_return(@user)
+      allow(BackEndFacade).to receive(:get_user).with(user.id).and_return(user)
       allow(BackEndFacade).to receive(:get_profile_user).with(user10.id.to_s).and_return(user10)
-      allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([user10])
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([user10])
       allow(BackEndFacade).to receive(:get_user_friends).with(user10.id).and_return([])
     end
 
@@ -64,11 +66,11 @@ describe 'user profile page: friend', type: :feature do
 
       it 'can remove an existing friend', :vcr do
         allow(BackEndService).to receive(:delete_friend).and_return(204)
-        allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
+        allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
 
         click_on 'Remove Friend'
 
-        expect(page).to have_current_path(dashboard_path(@user.id), ignore_query: true)
+        expect(page).to have_current_path(dashboard_path(user.id), ignore_query: true)
         expect(page).to have_content 'Swolemate removed!'
       end
     end

--- a/spec/features/users/profile/profile_friend_spec.rb
+++ b/spec/features/users/profile/profile_friend_spec.rb
@@ -22,6 +22,7 @@ describe 'user profile page: friend', type: :feature do
   let(:user10) { User.new(user10_params) }
 
   context 'when I log in as an authenticated user', :vcr do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     before do

--- a/spec/features/users/profile/profile_non_friend_spec.rb
+++ b/spec/features/users/profile/profile_non_friend_spec.rb
@@ -22,6 +22,7 @@ describe 'user profile page: non-friend', type: :feature do
   let(:user10) { User.new(user10_params) }
 
   context 'when I log in as an authenticated user', :vcr do
+    # See spec/shared_contexts/features/current_user_shared_context.rb for context
     include_context 'logged in as authenticated user'
 
     before do

--- a/spec/features/users/profile/profile_non_friend_spec.rb
+++ b/spec/features/users/profile/profile_non_friend_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'user profile page: non-friend', type: :feature do
-  let(:user1_params) do
+  let(:user10_params) do
     {
       id: 11,
       attributes: {
@@ -19,13 +19,15 @@ describe 'user profile page: non-friend', type: :feature do
     }
   end
 
-  let(:user10) { User.new(user1_params) }
+  let(:user10) { User.new(user10_params) }
 
   context 'when I log in as an authenticated user', :vcr do
+    include_context 'logged in as authenticated user'
+
     before do
-      allow(BackEndFacade).to receive(:get_user).with(@user.id).and_return(@user)
+      allow(BackEndFacade).to receive(:get_user).with(user.id).and_return(user)
       allow(BackEndFacade).to receive(:get_profile_user).with(user10.id.to_s).and_return(user10)
-      allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
       allow(BackEndFacade).to receive(:get_user_friends).with(user10.id).and_return([])
     end
 
@@ -63,12 +65,12 @@ describe 'user profile page: non-friend', type: :feature do
       end
 
       it 'can add a new friend', :vcr do
-        allow(BackEndService).to receive(:create_friendship).and_return(user1_params)
-        allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
+        allow(BackEndService).to receive(:create_friendship).and_return(user10_params)
+        allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
 
         click_on 'Add Friend'
 
-        expect(page).to have_current_path(dashboard_path(@user.id), ignore_query: true)
+        expect(page).to have_current_path(dashboard_path(user.id), ignore_query: true)
         expect(page).to have_content('go get them gains!!')
       end
     end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'registration page', type: :feature do
+  include_context 'logged in as authenticated user'
+
   describe 'happy path' do
     let(:user_blob) { File.read('./spec/fixtures/user.json') }
 
@@ -22,9 +24,9 @@ describe 'registration page', type: :feature do
     end
 
     it 'can register a new user if all required attributes are provided', :vcr do
-      allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
-      allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
-      allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([])
 
       visit registration_path
 
@@ -32,9 +34,9 @@ describe 'registration page', type: :feature do
       allow(BackEndService).to receive(:get_user)
         .and_return(JSON.parse(user_blob, symbolize_names: true))
 
-      allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
-      allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
-      allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
+      allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([])
 
       fill_in :full_name, with: 'Foo Bar'
       fill_in :email, with: 'test@testing.com'

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe 'registration page', type: :feature do
+  # See spec/shared_contexts/features/current_user_shared_context.rb for context
   include_context 'logged in as authenticated user'
 
   describe 'happy path' do

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'registration page' do
+describe 'registration page', type: :feature do
   describe 'happy path' do
     let(:user_blob) { File.read('./spec/fixtures/user.json') }
 

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'welcome page', type: :feature do
+  include_context 'logged in as authenticated user'
+
   let(:user_blob) { File.read('./spec/fixtures/user.json') }
 
   it 'is on the correct page' do
@@ -11,23 +13,23 @@ describe 'welcome page', type: :feature do
   end
 
   it 'can log in and out of the application with a valid Google token', :aggregate_failures, :vcr do
-    allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
-    allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
-    allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([])
 
     visit root_path
 
     allow(BackEndService).to receive(:get_user)
       .and_return(JSON.parse(user_blob, symbolize_names: true))
 
-    allow(BackEndFacade).to receive(:get_user_friends).with(@user.id).and_return([])
-    allow(BackEndFacade).to receive(:get_user_gyms).with(@user.id).and_return([])
-    allow(BackEndFacade).to receive(:get_user_events).with(@user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_friends).with(user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_gyms).with(user.id).and_return([])
+    allow(BackEndFacade).to receive(:get_user_events).with(user.id).and_return([])
 
     # helper method defined in spec/support
     # see bottom of rails_helper for OmniAuth mock
     login_with_oauth
-    expect(page).to have_current_path(dashboard_path(@user.id), ignore_query: true)
+    expect(page).to have_current_path(dashboard_path(user.id), ignore_query: true)
 
     expect(page).to have_link 'Dashboard'
     expect(page).to have_button 'Find Gyms Near Me'

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'welcome page' do
+describe 'welcome page', type: :feature do
   let(:user_blob) { File.read('./spec/fixtures/user.json') }
 
   it 'is on the correct page' do

--- a/spec/poros/event_spec.rb
+++ b/spec/poros/event_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Event, type: :poro do
+describe Event, type: :poro do
   it 'can initialize from event params' do
     id = '1'
     user_id = 1

--- a/spec/poros/gym_membership_spec.rb
+++ b/spec/poros/gym_membership_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GymMembership, type: :poro do
+describe GymMembership, type: :poro do
   describe 'object creation' do
     it 'initialize from given parameters params' do
       gym_membership_id = '1'

--- a/spec/poros/gym_membership_spec.rb
+++ b/spec/poros/gym_membership_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GymMembership, type: :poro do
+  describe 'object creation' do
+    it 'initialize from given parameters params' do
+      gym_membership_id = '1'
+      yelp_gym_id = 'lex65fkcol5gfq89rymmd2'
+      gym_name = 'Planet Fitness'
+
+      gym_membership_params = {
+        id: gym_membership_id,
+        type: 'gym_membership',
+        attributes: {
+          user_id: 1,
+          yelp_gym_id: yelp_gym_id,
+          gym_name: gym_name
+        }
+      }
+
+      gym_membership = GymMembership.new(gym_membership_params)
+
+      expect(gym_membership).to be_an_instance_of(GymMembership)
+      expect(gym_membership.yelp_gym_id).to eq(yelp_gym_id)
+      expect(gym_membership.yelp_gym_id).to be_a String
+      expect(gym_membership.gym_name).to eq(gym_name)
+      expect(gym_membership.gym_name).to be_a String
+      expect(gym_membership.id).to eq(gym_membership_id)
+      expect(gym_membership.id).to be_a String
+    end
+  end
+end

--- a/spec/poros/gym_spec.rb
+++ b/spec/poros/gym_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Gym, type: :poro do
+describe Gym, type: :poro do
   describe 'object creation' do
     it 'initialize from given parameters params' do
       yelp_gym_id = '1'

--- a/spec/poros/gym_user_count_spec.rb
+++ b/spec/poros/gym_user_count_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe GymUserCount, type: :poro do
+  describe 'object creation' do
+    it 'initialize from given parameters params' do
+      count = 15
+      gym_member_count = { gym_member_count: count }
+      gym_membership = GymUserCount.new(gym_member_count)
+
+      expect(gym_membership).to be_an_instance_of(GymUserCount)
+      expect(gym_membership.gym_member_count).to eq(count)
+      expect(gym_membership.gym_member_count).to be_an Integer
+    end
+  end
+end

--- a/spec/poros/gym_user_count_spec.rb
+++ b/spec/poros/gym_user_count_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe GymUserCount, type: :poro do
+describe GymUserCount, type: :poro do
   describe 'object creation' do
     it 'initialize from given parameters params' do
       count = 15

--- a/spec/poros/user_spec.rb
+++ b/spec/poros/user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :poro do
+describe User, type: :poro do
   it 'can initialize from user params' do
     user_params = {
       id: 1,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,8 +5,8 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
-require './spec/support/integration_spec_helper'
 require 'simplecov'
 SimpleCov.start do
   add_filter 'spec/'
@@ -27,11 +27,10 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
-  # config.filter_sensitive_data('DONT_SHARE_MY_PROPUBLIC_SECRET_KEY') { ENV['PROPUBLICA_KEY'] }
   config.default_cassette_options = { re_record_interval: 7.days }
   config.configure_rspec_metadata!
-  # config.allow_http_connections_when_no_cassette = true
 end
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -45,7 +44,7 @@ end
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -58,12 +57,7 @@ end
 RSpec.configure do |config|
   # see spec/support for omniauth login helper method
   config.include IntegrationSpecHelper, :type => :feature
-  # hook for ApplicationController.current_user
-  config.before(:each, type: :feature) do
-    @user = ApplicationRecord.user_stub
 
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-  end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/services/back_end_service_spec.rb
+++ b/spec/services/back_end_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BackEndService do
+describe BackEndService, type: :service do
   it 'can retrieve the base url for API calls' do
     expect(BackEndService.base_url.class).to eq String
   end

--- a/spec/support/shared_contexts/features/current_user_shared_context.rb
+++ b/spec/support/shared_contexts/features/current_user_shared_context.rb
@@ -1,0 +1,24 @@
+shared_context 'logged in as authenticated user' do
+  let(:user) do
+    User.new(
+      id: 1,
+      attributes: {
+        email: '123@test.com',
+        full_name: 'Joe Shmoe',
+        google_id: 789,
+        google_image_url: 'pretty face',
+        zip_code: '80227',
+        summary: 'Muy guesta gimnasios',
+        goal: 'Gain Muscle',
+        availability_morning: true,
+        availability_afternoon: true,
+        availability_evening: false
+      }
+    )
+  end
+
+  before do
+    allow_any_instance_of(ApplicationController)
+      .to receive(:current_user).and_return(user)
+  end
+end


### PR DESCRIPTION
### Changes Implemented:
  - Use shared examples to stub out `current_user` and define as `user` within a let block.
    - For future tests that need a logged-in user, use the following code within the top of your describe block and `user` can be called by simply calling `user` (no `@` needed!): 
      ```ruby
      # example feature spec
      describe 'user profile page: current user', type: :feature do
        context 'when I log in as an authenticated user' do
          include_context 'logged in as authenticated user'
          [...]
        end
      end
      ```
  - Backfilled PORO tests
  - Added spec type at the top of each spec file (e.g. `type: :feature`)

### Quality Control Checklist:

  - [ ] Code adheres to Rubocop styling.  If not, please clarify below:
    - There are some infractions that we could clean up.  I will address this as I populate this pull request.
  - [ ] 100% SimpleCov test coverage.  If not, please clarify below:
    - We are not currently at 100%, but I will continue addressing this as I populate this pull request.

### Blockers (if applicable):
  - None

### Next Steps & Additional Notes:
  - TBD